### PR TITLE
Footer Position

### DIFF
--- a/public/css/all.css
+++ b/public/css/all.css
@@ -131,6 +131,9 @@ body {
 {
 	text-align:center;
 	font-size: 83%;
+	bottom: 0; 
+        position: fixed; 
+        width: 100%;
 }
 
 


### PR DESCRIPTION
Currently, it is annoying to see the footer section(mainly "© 2019 - Powered by PHPBack") floating relative to the height of the screen and sometimes it shows up in the middle or at the height of 70-90% of the screen.

So, my fix will stick it to the absolute footer, it's the ideal position.