### PR TITLE
Hide DB Details

### DIFF
--- a/system/language/english/db_lang.php
+++ b/system/language/english/db_lang.php
@@ -2,8 +2,8 @@
 
 $lang['db_invalid_connection_str'] = 'Unable to determine the database settings based on the connection string you submitted.';
 $lang['db_unable_to_connect'] = 'Unable to connect to your database server using the provided settings.';
-$lang['db_unable_to_select'] = 'Unable to select the specified database: %s';
-$lang['db_unable_to_create'] = 'Unable to create the specified database: %s';
+$lang['db_unable_to_select'] = 'Unable to connect to the database.';
+$lang['db_unable_to_create'] = 'Unable to create the database.';
 $lang['db_invalid_query'] = 'The query you submitted is not valid.';
 $lang['db_must_set_table'] = 'You must set the database table to be used with your query.';
 $lang['db_must_use_set'] = 'You must use the "set" method to update an entry.';


### PR DESCRIPTION
Currently, it is showing the error message on the screen like "Unable to select the specified database: <DB_NAME>" when there is an issue.

This fix will not display the <DB_NAME>, because it is sensitive information and not recommended to expose it directly on the website, not even in the logs.