### PR TITLE
Show ideas one status at a time

### DIFF
--- a/application/controllers/home.php
+++ b/application/controllers/home.php
@@ -45,14 +45,14 @@ class Home extends CI_Controller {
 
 	}
 
-	public function category($id, $name = "", $order = "votes", $type = "desc", $page = '1') {
-        if (!$this->get->categoryExists($id)){
+	public function category($id, $name = "", $order = "votes", $type = "desc", $page = '1', $status = "considered") {
+        if (!$this->get->categoryExists($id) || 'new' == $status) {
             header('Location: ' . base_url() . 'home');
             return;
         }
 
         $data = $this->getDefaultData();
-        $data['ideas'] = $this->get->getIdeasByCategory($id, $order, $type, $page);
+        $data['ideas'] = $this->get->getIdeasByCategory($id, $order, $type, $page, $status);
         $data['category'] = $data['categories'][$id];
         $total = $this->get->getQuantityOfApprovedIdeas($id);
         $data['max_results'] = (int) $this->get->getSetting('max_results');
@@ -61,6 +61,8 @@ class Home extends CI_Controller {
         if(($total % $data['max_results']) > 0) $data['pages']++;
         $data['type'] = $type;
         $data['order'] = $order;
+		$data['fullUrl'] = $data['category']->url . "/" . $data['order'] . "/" . $data['type'] . "/1";
+		$data['idea_status'] = 'idea_' . $status;
 
         $this->load->view('_templates/header', $data);
 		$this->load->view('home/category_ideas', $data);

--- a/application/language/bahasa indonesia/default_lang.php
+++ b/application/language/bahasa indonesia/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Kirim';
     $lang['label_vote'] = 'Voting';
     $lang['label_votes'] = 'Voting';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'bagikan ide ini';
     $lang['text_flag_comment'] = 'tandai komentar';

--- a/application/language/chinese/default_lang.php
+++ b/application/language/chinese/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = '提交';
     $lang['label_vote'] = '投票';
     $lang['label_votes'] = '投票';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = '分享想法';
     $lang['text_flag_comment'] = '标记评论';

--- a/application/language/dutch/default_lang.php
+++ b/application/language/dutch/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Versturen';
     $lang['label_vote'] = 'Stem';
     $lang['label_votes'] = 'Stemmen';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'heeft dit idee gedeeld';
     $lang['text_flag_comment'] = 'flag reactie';

--- a/application/language/english/default_lang.php
+++ b/application/language/english/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Submit';
     $lang['label_vote'] = 'Vote';
     $lang['label_votes'] = 'Votes';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'shared this idea';
     $lang['text_flag_comment'] = 'flag comment';

--- a/application/language/french/default_lang.php
+++ b/application/language/french/default_lang.php
@@ -30,6 +30,7 @@ $lang['label_sign_in'] = 'Se connecter';
 $lang['label_submit'] = 'Soumettre';
 $lang['label_vote'] = 'Vote';
 $lang['label_votes'] = 'Votes';
+$lang['label_status'] = 'Statut';
 
 $lang['text_shared_this_idea'] = 'a partagé cette idée';
 $lang['text_flag_comment'] = 'signaler commentaire';

--- a/application/language/german/default_lang.php
+++ b/application/language/german/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Übermitteln';
     $lang['label_vote'] = 'Wählen';
     $lang['label_votes'] = 'Stimmen';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'Idee teilen';
     $lang['text_flag_comment'] = 'Kommentar markieren';

--- a/application/language/japanese/default_lang.php
+++ b/application/language/japanese/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = '送信';
     $lang['label_vote'] = '投票';
     $lang['label_votes'] = '投票';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'この考えを共有しました';
     $lang['text_flag_comment'] = 'flag comment';

--- a/application/language/portuguese-european/default_lang.php
+++ b/application/language/portuguese-european/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Enviar';
     $lang['label_vote'] = 'Votar';
     $lang['label_votes'] = 'Votos';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'partilhou esta ideia';
     $lang['text_flag_comment'] = 'marcar comentário';

--- a/application/language/portuguese/default_lang.php
+++ b/application/language/portuguese/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Enviar';
     $lang['label_vote'] = 'Votar';
     $lang['label_votes'] = 'Votos';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'compartilhou esta idéia';
     $lang['text_flag_comment'] = 'marcar comentário';

--- a/application/language/spanish/default_lang.php
+++ b/application/language/spanish/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'Enviar';
     $lang['label_vote'] = 'Votar';
     $lang['label_votes'] = 'Votos';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'ha compartido esta idea';
     $lang['text_flag_comment'] = 'reportar comentario';

--- a/application/language/thai/default_lang.php
+++ b/application/language/thai/default_lang.php
@@ -30,6 +30,7 @@
     $lang['label_submit'] = 'ส่ง';
     $lang['label_vote'] = 'โหวต';
     $lang['label_votes'] = 'โหวต';
+    $lang['label_status'] = 'Status';
 
     $lang['text_shared_this_idea'] = 'แบ่งปันไอเดีย';
     $lang['text_flag_comment'] = 'ติดธงข้อเสนอแนะ';

--- a/application/models/get.php
+++ b/application/models/get.php
@@ -105,12 +105,12 @@ class Get extends CI_Model
         return true;
     }
 
-    public function getIdeasByCategory($category, $order, $type, $page){
+    public function getIdeasByCategory($category, $order, $type, $page, $status){
         $page = (int) $page;
     	$category = (int) $category;
         $max = $this->getSetting('max_results');
         $from = ($page - 1) * $max;
-    	$query = "SELECT * FROM ideas WHERE categoryid='$category' AND status !='new' ORDER BY ";
+    	$query = "SELECT * FROM ideas WHERE categoryid='$category' AND status = '$status' ORDER BY ";
         switch ($order) {
             case 'id':
                 $query .= "id ";
@@ -165,6 +165,9 @@ class Get extends CI_Model
         return $this->get_row_by_id('users', $user_id);
     }
 
+    /**
+     * Get all ideas a user has created
+     */
     public function getUserIdeas($user_id){
         $user_id = (int) $user_id;
         $ideas = $this->db->query("SELECT * FROM ideas WHERE authorid='$user_id'")->result();

--- a/application/views/home/category_ideas.php
+++ b/application/views/home/category_ideas.php
@@ -22,6 +22,7 @@
 			</div>
 
 			<div style="color:#34495E"><small><?php echo $category->description; ?></small></div>
+			<div id="category-description"><small><?php echo $category->description; ?></small></div>
 		</div>
 
 		<table id="ideastable" class="table table-condensed">

--- a/application/views/home/category_ideas.php
+++ b/application/views/home/category_ideas.php
@@ -21,7 +21,6 @@
 				</ul>
 			</div>
 
-			<div style="color:#34495E"><small><?php echo $category->description; ?></small></div>
 			<div id="category-description"><small><?php echo $category->description; ?></small></div>
 		</div>
 

--- a/application/views/home/category_ideas.php
+++ b/application/views/home/category_ideas.php
@@ -1,5 +1,5 @@
 	<div class="col-md-9">
-	
+
 		<div class="breadcrumb-wrapper"><ol class="breadcrumb">
 			<li><a href="<?php echo base_url();?>">Feedback</a></li>
 			<li class="active"><?php echo $category->name; ?></li>
@@ -21,7 +21,7 @@
 				</ul>
 			</div>
 
-			<div id="category-description"><small><?php echo $category->description; ?></small></div>
+			<div class="category-description"><small><?php echo $category->description; ?></small></div>
 		</div>
 
 		<table id="ideastable" class="table table-condensed">
@@ -34,7 +34,7 @@
 			</tr>
 		</thead>
 		</table>
-		
+
 		<?php foreach ($ideas as $idea): ?>
 			<div class="row">
 				<div class="col-xs-4 col-sm-2">
@@ -55,7 +55,7 @@
 						</b></span>
 						<br><div style="margin-top:-10px;font-size:14px"><?php echo $lang['label_votes']; ?></div>
 					</div>
-					<div class="vote-label">	
+					<div class="vote-label">
 						<span class="label label-<?php
 						switch ($idea->status) {
 							case 'considered':

--- a/application/views/home/category_ideas.php
+++ b/application/views/home/category_ideas.php
@@ -6,8 +6,24 @@
 		</ol></div>
 		<div>
 			<h5 style="color:#2C3E50;"><?php echo $category->name; ?></h5>
-			<span style="color:#34495E"><small><?php echo $category->description; ?></small></span>
+			<div class="dropdown pull-right">
+				<button class="btn btn-default btn-sm dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+					<?= $lang['label_status'] ?> : <?= $lang[$idea_status] ?>
+					<span class="caret"></span>
+				</button>
+				<span class="dropdown-arrow dropdown-arrow-inverse"></span>
+				<ul class="dropdown-menu dropdown-inverse" aria-labelledby="dropdownMenu1">
+					<li><a href="<?= $fullUrl ?>/declined"><?= $lang['idea_declined'] ?></a></li>
+					<li><a href="<?= $fullUrl ?>/considered"><?= $lang['idea_considered'] ?></a></li>
+					<li><a href="<?= $fullUrl ?>/planned"><?= $lang['idea_planned'] ?></a></li>
+					<li><a href="<?= $fullUrl ?>/started"><?= $lang['idea_started'] ?></a></li>
+					<li><a href="<?= $fullUrl ?>/completed"><?= $lang['idea_completed'] ?></a></li>
+				</ul>
+			</div>
+
+			<div style="color:#34495E"><small><?php echo $category->description; ?></small></div>
 		</div>
+
 		<table id="ideastable" class="table table-condensed">
 		<thead>
 			<tr>

--- a/application/views/home/view_idea.php
+++ b/application/views/home/view_idea.php
@@ -154,7 +154,7 @@
 							<?php endif;?>
 							</span>
 						<div class="comment-text">
-							<?php echo $comment->content;?>
+							<?php echo nl2br($comment->content);?>
 						</div>
 					 </div>
 				</div>

--- a/public/css/all.css
+++ b/public/css/all.css
@@ -142,3 +142,6 @@ body {
 	vertical-align:2px;
 }
 
+#category-description {
+    color: #34495E
+}

--- a/public/css/all.css
+++ b/public/css/all.css
@@ -138,10 +138,10 @@ body {
 
 
 /* Line up labels and badges with text better */
-.label, .badge { 
+.label, .badge {
 	vertical-align:2px;
 }
 
-#category-description {
+.category-description {
     color: #34495E
 }


### PR DESCRIPTION
I felt very frustrated by the ideas current display so I improved it a little.
![idea-status](https://user-images.githubusercontent.com/5312739/57693834-77bc5700-764a-11e9-9276-0bf6b60a60f9.png)

IMO, when an user want to see ideas, he doesn't really want to see *all ideas*. Only the current pipeline is important, ie. considered ideas. That's why the current status filter is set on 'considered'. 
But, it might be useful to list ideas of another type, but only one status at a time. To support this UX I designed a select allowing to choose a status in header's list. Ideas obviously remain sorted by vote DESC.

For sure, I may be wrong and in that case, don't hesitate to close this PR.

Thanks !